### PR TITLE
 On branch feature/stylefix

### DIFF
--- a/includes/Views/agent-template.php
+++ b/includes/Views/agent-template.php
@@ -58,9 +58,9 @@ $features = \PBCRAgentMode\Helpers\PropertyData::get_formatted_features($propert
 <body class="agent-mode">
 	<div class="agent-mode-container">
 		<header class="agent-mode-header">
-			<div>
+			<div class="property-header-info">
 				<?php if (! empty($property_data['breadcrumbs']) && is_array($property_data['breadcrumbs'])) : ?>
-					<p class="status"><?php echo esc_html(implode(' › ', $property_data['breadcrumbs'])); ?></p>
+					<p class="status status-breadcrumbs"><?php echo esc_html(implode(' › ', $property_data['breadcrumbs'])); ?></p>
 				<?php endif; ?>
 				<h1 class="property-title"><?php echo esc_html(get_the_title()); ?></h1>
 			</div>
@@ -281,14 +281,6 @@ $features = \PBCRAgentMode\Helpers\PropertyData::get_formatted_features($propert
 	<!-- Direct Swiper JS inclusion -->
 	<script src="<?php echo PBCR_AGENT_MODE_PLUGIN_URL . 'includes/js/swiper-bundle.min.js'; ?>?v=<?php echo PBCR_AGENT_MODE_VERSION; ?>"></script>
 	<script src="<?php echo PBCR_AGENT_MODE_PLUGIN_URL . 'includes/js/agent-mode.js'; ?>?v=<?php echo PBCR_AGENT_MODE_VERSION; ?>"></script>
-	<script>
-		// (function () {
-		// 	if (location.search.includes('agent_view=1')) {
-		// 		const slug = 'mc-' + Math.random().toString(36).slice(2, 6)
-		// 		history.replaceState({}, '', '/' + slug)
-		// 	}
-		// })()
-	</script>
 </body>
 
 </html>

--- a/includes/css/agent-style.css
+++ b/includes/css/agent-style.css
@@ -59,10 +59,18 @@ html:has(.agent-mode) {
 		max-width: 1000px;
 		margin: 0 auto 2rem;
 
+
 		& .property_price {
+			border-top: 1px solid lightgray;
+			padding-top: 1rem;
+			margin-top: 1rem;
+
 			@container main-content (min-width: 768px) {
 				border-left: 1px solid lightgray;
 				padding-left: 1rem;
+				border-top: none;
+				padding-top: 0;
+				margin-top: 0;
 			}
 		}
 
@@ -80,12 +88,18 @@ html:has(.agent-mode) {
 			font-weight: 500;
 		}
 
+		& .status-breadcrumbs {
+			@container main-content (max-width: 768px) {
+				font-size: 1.125rem;
+			}
+		}
+
 		& .price {
 			margin-bottom: -4px;
 		}
 
 		& .property-price-wrapper {
-			font-size: clamp(1.5rem, 3vw, 2.5rem);
+			font-size: 2.5rem;
 			font-weight: 400;
 		}
 	}
@@ -155,6 +169,7 @@ html:has(.agent-mode) {
 			/* Property Reference ID */
 			& .property-ref {
 				font-size: 1.75rem;
+				font-weight: 500;
 				color: #6b7280;
 				display: flex;
 				align-items: center;
@@ -165,7 +180,6 @@ html:has(.agent-mode) {
 				}
 
 				& .ref-value {
-					font-family: monospace;
 					background: #f3f4f6;
 					padding: 0.25rem 0.5rem;
 					border-radius: 4px;
@@ -384,6 +398,10 @@ html:has(.agent-mode) {
 				list-style: none;
 				padding: 0;
 				margin: 0;
+
+				@container main-content (max-width: 768px) {
+					grid-template-columns: repeat(2, 1fr);
+				}
 
 				& .feature-bullet {
 					display: none;
@@ -767,7 +785,7 @@ html:has(.agent-mode) {
 @media (max-width: 767px) {
 	.agent-mode {
 		& .agent-mode-container {
-			padding: 0.75rem;
+			padding: 0.75rem 2rem;
 		}
 
 		& .property-title {


### PR DESCRIPTION
This pull request introduces several improvements to the agent mode property listing template and its styling, focusing on better visual hierarchy, responsive design, and code cleanup. The most important changes are grouped below by theme.

**Visual and Structural Enhancements:**

* Added the `property-header-info` class to the header container and a dedicated `status-breadcrumbs` class to the breadcrumbs element in `agent-template.php` for improved semantic structure and easier styling.
* Updated the `.property_price` section to add a top border and spacing for better separation on mobile, and removed these on larger screens for a cleaner layout.
* Increased font weight for the `.property-ref` element to improve emphasis and readability.

**Responsive Design Improvements:**

* Added a responsive rule for `.status-breadcrumbs` to increase font size on screens narrower than 768px, improving mobile readability.
* Adjusted the grid layout for `.property-features` to display two columns on screens under 768px, enhancing feature visibility on mobile devices.
* Increased horizontal padding for `.agent-mode-container` on small screens to improve content spacing.

**Code Cleanup:**

* Removed an unused inline script from the bottom of `agent-template.php` that was previously commented out, reducing unnecessary code.
* Removed the monospace font from `.ref-value` for a more consistent look with the rest of the UI.