### PR TITLE
 On branch feature/fix-error

### DIFF
--- a/.prompts/task-23.json
+++ b/.prompts/task-23.json
@@ -1,7 +1,7 @@
 {
   "task": "Enqueue agent-copy-btn.js globally for Agent Mode",
   "description": "Ensure that the agent copy button script is enqueued on all property single pages regardless of block usage. The script is already working, it just needs to be properly enqueued via wp_enqueue_scripts.",
-  "script_path": "assets/js/agent-copy-btn.js",
+  "script_path": "Assets/js/agent-copy-btn.js",
   "enqueue_logic": {
     "hook": "wp_enqueue_scripts",
     "function_name": "pbcr_enqueue_agent_copy_script",

--- a/includes/Loader.php
+++ b/includes/Loader.php
@@ -30,9 +30,6 @@ class Loader {
 
 		// Register shortcodes.
 		$this->register_shortcodes();
-
-		// Register blocks.
-		$this->register_blocks();
 	}
 
 	/**
@@ -49,13 +46,5 @@ class Loader {
 	private function register_shortcodes() {
 		$agent_view_link_button = new Shortcodes\AgentViewLinkButton();
 		$agent_view_link_button->register();
-	}
-
-	/**
-	 * Register all blocks.
-	 */
-	private function register_blocks() {
-		$agent_copy_button_block = new Blocks\AgentCopyButton();
-		$agent_copy_button_block->register();
 	}
 }

--- a/includes/css/agent-copy-btn.css
+++ b/includes/css/agent-copy-btn.css
@@ -10,7 +10,7 @@
 	align-items: center;
 	gap: 0.5rem;
 	padding: 0.5rem 1rem;
-	font-size: 0.75rem;
+	font-size: 1.25rem;
 	font-weight: 500;
 	line-height: 1.5;
 	text-decoration: none;

--- a/includes/css/agent-style.css
+++ b/includes/css/agent-style.css
@@ -223,7 +223,7 @@ html:has(.agent-mode) {
 						display: block;
 
 						&.feature-icon-bed::before {
-							background: url("../assets/rooms.svg") no-repeat
+							background: url("../Assets/rooms.svg") no-repeat
 								center center;
 							background-size: contain;
 							content: "";
@@ -233,7 +233,7 @@ html:has(.agent-mode) {
 						}
 
 						&.feature-icon-bath::before {
-							background: url("../assets/bathrooms.svg") no-repeat
+							background: url("../Assets/bathrooms.svg") no-repeat
 								center center;
 							background-size: contain;
 							content: "";
@@ -243,7 +243,7 @@ html:has(.agent-mode) {
 						}
 
 						&.feature-icon-garage::before {
-							background: url("../assets/garage.svg") no-repeat
+							background: url("../Assets/garage.svg") no-repeat
 								center center;
 							background-size: contain;
 							content: "";
@@ -253,7 +253,7 @@ html:has(.agent-mode) {
 						}
 
 						&.feature-icon-size::before {
-							background: url("../assets/size.svg") no-repeat
+							background: url("../Assets/size.svg") no-repeat
 								center center;
 							background-size: contain;
 							content: "";
@@ -263,7 +263,7 @@ html:has(.agent-mode) {
 						}
 
 						&.feature-icon-land::before {
-							background: url("../assets/land.svg") no-repeat
+							background: url("../Assets/land.svg") no-repeat
 								center center;
 							background-size: contain;
 							content: "";


### PR DESCRIPTION
This pull request primarily focuses on improving how assets are referenced and loaded for Agent Mode, as well as making a style adjustment to the agent copy button. The most important changes include standardizing asset paths to use `Assets/` instead of `assets/`, removing block registration logic from the loader, and updating the font size for the agent copy button.

**Asset Path Standardization:**

* Updated all asset references in `agent-style.css` and the agent copy button script path in `.prompts/task-23.json` to use `Assets/` instead of `assets/` for consistency and to prevent potential loading issues. [[1]](diffhunk://#diff-b55d08787b526d338843352d0d27f31231425e0d786862bef84f607a8a982841L226-R226) [[2]](diffhunk://#diff-b55d08787b526d338843352d0d27f31231425e0d786862bef84f607a8a982841L236-R236) [[3]](diffhunk://#diff-b55d08787b526d338843352d0d27f31231425e0d786862bef84f607a8a982841L246-R246) [[4]](diffhunk://#diff-b55d08787b526d338843352d0d27f31231425e0d786862bef84f607a8a982841L256-R256) [[5]](diffhunk://#diff-b55d08787b526d338843352d0d27f31231425e0d786862bef84f607a8a982841L266-R266) [[6]](diffhunk://#diff-831cce1ef73194a276b1c12b6c50dcec1126d64f2155916eebaf831ed96d36b3L4-R4)

**Loader Refactoring:**

* Removed block registration logic from `Loader.php` by deleting the `register_blocks()` method and its invocation, simplifying the loader to only handle shortcode registration. [[1]](diffhunk://#diff-119c8e412584b76761513163cbd15e3c143afcfc18882672b47857782ec13d2aL33-L35) [[2]](diffhunk://#diff-119c8e412584b76761513163cbd15e3c143afcfc18882672b47857782ec13d2aL53-L60)

**Style Improvements:**

* Increased the font size of the agent copy button in `agent-copy-btn.css` from `0.75rem` to `1.25rem` for better visibility and usability.